### PR TITLE
Use `performance` only when needed

### DIFF
--- a/llama-tokenizer.js
+++ b/llama-tokenizer.js
@@ -216,7 +216,11 @@ const mapCharactersToTokenIds = (prompt, add_bos_token, add_preceding_space) => 
 
 const encode = (prompt, add_bos_token=true, add_preceding_space=true, log_performance=false) => {
 
-    const startTime = performance.now()
+    let startTime = null
+    if (log_performance) {
+        startTime = performance.now()
+    }
+
     if (!llamaTokenizer.vocabById || !llamaTokenizer.vocabByString || !llamaTokenizer.merges) {
         console.log('Tokenizer not initialized properly!')
         return


### PR DESCRIPTION
Use the `performance.now()` only when `log_performance` is set. `performance` might not be available in some environments like `Next.js`